### PR TITLE
Adds missing step in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ This project uses Spring-Boot to start up a WebServer and contains a skeleton we
 * Download the solclientjs javascript libraries 
 * Place the solclientjs /lib directory under web-app-server/src/main/resources/static/
 * Copy and rename application-template.properties to application.properties
+* Change directory `cd src`
 
 To run the web-server, type the following command:
 


### PR DESCRIPTION
When the developer tries to follow the step in the base README they get an error (see screenshot). This is due to the fact that the dev is still in parent directory which does not contain `pom.xml`. 
The PR is adding a simple step to cd in the `src` directory so user does not face the error.

![image](https://user-images.githubusercontent.com/169889/211464563-bcc09216-357e-4250-9aed-00ebff518e25.png)
